### PR TITLE
feat(agents): 添加代理列表表格视图和空状态组件

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-query": "^5.80.7",
+    "@tanstack/react-table": "^8.21.3",
     "@trpc/client": "^11.3.1",
     "@trpc/server": "^11.3.1",
     "@trpc/tanstack-react-query": "^11.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.80.7
         version: 5.80.7(react@19.1.0)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@trpc/client':
         specifier: ^11.3.1
         version: 11.3.1(@trpc/server@11.3.1(typescript@5.8.3))(typescript@5.8.3)
@@ -1821,6 +1824,17 @@ packages:
     resolution: {integrity: sha512-u2F0VK6+anItoEvB3+rfvTO9GEh2vb00Je05OwlUe/A0lkJBgW1HckiY3f9YZa+jx6IOe4dHPh10dyp9aY3iRQ==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@trpc/client@11.3.1':
     resolution: {integrity: sha512-UlLsUN7x8qD07FaGzdz/FG3K+kpaYowZkmVZ8R4Nlx1Yj01Kgr1Y+cGjtBdRpd+0l7uVylwDPmHA1OxYE6zHgA==}
@@ -5132,6 +5146,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.80.7
       react: 19.1.0
+
+  '@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@trpc/client@11.3.1(@trpc/server@11.3.1(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:

--- a/public/empty.svg
+++ b/public/empty.svg
@@ -1,0 +1,40 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -1,0 +1,21 @@
+import Image from "next/image";
+
+interface Props {
+    title: string;
+    description: string;
+}
+
+export const EmptyState = ({
+    title,
+    description
+}: Props) => {
+    return (
+        <div className="flex flex-1 items-center justify-center">
+            <Image src="/logo.svg" alt="Empty" width={240} height={240} />
+            <div className="flex flex-col gap-y-6 max-w-md mx-auto text-center">
+                <h6 className="text-lg font-medium">{title}</h6>
+                <p className="text-sm">{description}</p>
+            </div>
+        </div>
+    )
+}

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -2,13 +2,16 @@ import { db } from '@/db';
 import { agents } from '@/db/schema';
 import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
 import { agentsInsertSchema } from '../schema';
-import { eq } from 'drizzle-orm';
+import { eq, getTableColumns, sql } from 'drizzle-orm';
 import z from 'zod';
 
 export const agentsRouter = createTRPCRouter({
   // todo change getmany to use protectedProcedure
   getMany: protectedProcedure.query(async () => {
-    const data = await db.select().from(agents);
+    const data = await db.select({
+      meetingCount: sql<number>`5`,
+      ...getTableColumns(agents),
+    }).from(agents);
     // await new Promise((resolve) => {
     //     setTimeout(() => {
     //         resolve(1);
@@ -34,7 +37,10 @@ export const agentsRouter = createTRPCRouter({
     }),
     getOne: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
       const [existAgent] = await db
-        .select()
+        .select({
+          meetingCount: sql<number>`5`,
+          ...getTableColumns(agents),
+        })
         .from(agents)
         .where(eq(agents.id, input.id));
 

--- a/src/modules/agents/ui/components/columns.tsx
+++ b/src/modules/agents/ui/components/columns.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { AgentGetOne } from "../../types"
+import { GeneratedAvatar } from "@/components/generated-avatar"
+import { CornerDownRightIcon, VideoIcon } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+
+// This type is used to define the shape of our data.
+// You can use a Zod schema here if you want.
+export const columns: ColumnDef<AgentGetOne>[] = [
+  {
+    accessorKey: "name",
+    header: "Agent Name",
+    cell: ({ row }) => {
+
+      return (
+        <div className="flex flex-col gap-y-1">
+          <div className="flex items-center gap-x-2">
+            <GeneratedAvatar 
+              seed={row.original.name}
+              variants="botttsNeutral"
+              className="size-6"
+            />
+            <span className="">{row.original.name}</span>
+          </div>
+          <div className="flex items-center gap-x-2">
+            <CornerDownRightIcon className="size-3 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground max-w-[200px] truncate capitalize">
+              {row.original.instructions}
+            </span>
+          </div>
+        </div>
+      ); 
+    }
+  },
+  {
+    accessorKey: "meetingCount",
+    header: "Meetings",
+    cell: ({ row }) => {
+      return (
+        <Badge variant="outline" className="flex items-center gap-x-2">
+          <VideoIcon className="text-blue-700" />
+          5
+          { row.original.meetingCount } { row.original.meetingCount === 1 ? "meeting" : "meetings"}
+        </Badge>
+      );
+    }
+  }
+]

--- a/src/modules/agents/ui/components/data-table.tsx
+++ b/src/modules/agents/ui/components/data-table.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+} from "@/components/ui/table"
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[],
+  onRowClick?: (row: TData) => void;
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  onRowClick,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return (
+    <div className="rounded-lg border bg-background overflow-hidden">
+      <Table>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                onClick={() => onRowClick?.(row.original)}
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} className="text-sm p-4">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-19 text-center text-muted-foreground">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/src/modules/agents/ui/views/agents-view.tsx
+++ b/src/modules/agents/ui/views/agents-view.tsx
@@ -3,15 +3,26 @@ import { ErrorState } from "@/components/error-state";
 import { LoadingState } from "@/components/loading-state";
 import { useTRPC } from "@/trpc/client";
 import { useSuspenseQuery } from "@tanstack/react-query";
-
+import { columns } from "../components/columns";
+import { DataTable } from "../components/data-table";
+import { EmptyState } from "@/components/empty-state";
 
 export const AgentsView = () => {
   const trpc = useTRPC();
   const { data } = useSuspenseQuery(trpc.agents.getMany.queryOptions());
 
   return (
-    <div>
-     1111
+    <div className="flex-1 pb-4 md:px-8 flex flex-col gap-y-4">
+      <DataTable
+        columns={columns}
+        data={data}
+      />
+      {data.length === 0 && (
+        <EmptyState
+          title="No agents found"
+          description="You can create one by clicking the button below."
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
- 引入@tanstack/react-table实现代理数据表格展示
- 创建空状态组件用于无数据时的展示
- 修改后端接口添加meetingCount字段
- 添加表格相关组件和样式